### PR TITLE
Solution 1 things

### DIFF
--- a/solution_1.hs
+++ b/solution_1.hs
@@ -6,5 +6,6 @@ collect xs = sum $ zipWith (\x y -> if (x < y) then 1 else 0) xs $ drop 1 xs
 
 main :: IO ()
 main = do
-  let output = collect input where input = [199, 200, 208, 210, 200, 207, 240, 269, 260, 263]
+  let input = [199, 200, 208, 210, 200, 207, 240, 269, 260, 263]
+      output = collect input
   print output

--- a/solution_1.hs
+++ b/solution_1.hs
@@ -1,8 +1,11 @@
+{-# OPTIONS_GHC -Wall #-}
+
 collect :: [Int] -> Int
 collect []       = 0
-collect (x:[])   = 0
+collect (_:[])   = 0
 collect (x:y:xs) = (if (x < y) then 1 else 0) + collect (y:xs)
 
+main :: IO ()
 main = do
   let output = collect input where input = [199, 200, 208, 210, 200, 207, 240, 269, 260, 263]
   print output

--- a/solution_1.hs
+++ b/solution_1.hs
@@ -1,9 +1,8 @@
 {-# OPTIONS_GHC -Wall #-}
 
 collect :: [Int] -> Int
-collect []       = 0
-collect (_:[])   = 0
-collect (x:y:xs) = (if (x < y) then 1 else 0) + collect (y:xs)
+collect xs = sum $ zipWith (\x y -> if (x < y) then 1 else 0) xs $ drop 1 xs
+
 
 main :: IO ()
 main = do


### PR DESCRIPTION
This PR is a few changes I would make, one per commit.

88f21ae: Turn on `-Wall` in all of your modules. By default Haskell silently ignores a lot of serious warnings, and turning this on usually catches stupid bugs before you write them. You didn't have any, but I cleaned up a few warnings regarding unused variables and missing type signatures.

c1b4aba: There's a really common pattern in Haskell to pair up every pair of subsequent elements in a list: `zip xs (drop 1 xs)`. Then you can use `zipWith` instead of  `zip` to describe how to combine each pair. Finally, just `sum` the whole thing together! In general, it's easier to reason about your code if it doesn't have explicit recursion, and there are lots of super helpful functions in the standard library.

60481c8: `let output = collect input where input = ...` is a funny pattern. Better to just bind the input in the same `let`.